### PR TITLE
Throw slightly better errors by using prepare_V2

### DIFF
--- a/hdbc-sqlite3-helper.c
+++ b/hdbc-sqlite3-helper.c
@@ -91,8 +91,14 @@ int sqlite3_prepare2(finalizeonce *fdb, const char *zSql,
 #ifdef DEBUG_HDBC_SQLITE3
   fprintf(stderr, "\nCalling prepare on %p", db);
 #endif
+#if SQLITE_VERSION_NUMBER > 3003011
+  res = sqlite3_prepare_v2(db, zSql, nBytes, &ppst,
+                        pzTail);
+#else
   res = sqlite3_prepare(db, zSql, nBytes, &ppst,
                         pzTail);
+#endif
+
   /* We don't try to deallocate this in Haskell if there
      was an error. */
   if (res != SQLITE_OK) {


### PR DESCRIPTION
If I had more Haskell experience I'd probably add 2 new testcases:

CREATE TABLE blah (x INT NOT NULL)

prepare/execute (or run) "INSERT INTO blah VALUES (?);"
Bind with: toSql (Nothing :: Maybe Int)

Expected result: seNativeError: 19 (SQLITE_CONSTRAINT) and seErrorMessage: (something about a constraint error).

Use this pattern with both prepare/execute (or run) and fexecuteRaw.

This is much better than before this change which would yield:
SQLITE_ERROR        1   /\* SQL error or missing database */

Thanks,
Bill
