### PR TITLE
adding FlexibleContexts for GHC 7.10 (#14)

### DIFF
--- a/Database/HDBC/Sqlite3/Connection.hs
+++ b/Database/HDBC/Sqlite3/Connection.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# CFILES hdbc-sqlite3-helper.c #-}
 -- above line for hugs
 


### PR DESCRIPTION
With this patch, GHC 7.10.1 can compile hdbc-sqlite3.