### PR TITLE
Fix missing test source

### DIFF
--- a/HDBC-sqlite3.cabal
+++ b/HDBC-sqlite3.cabal
@@ -39,7 +39,6 @@ Library
   Extensions: ExistentialQuantification,
               ForeignFunctionInterface,
               EmptyDataDecls,
-              ScopedTypeVariables,
               ScopedTypeVariables
 
 Executable runtests
@@ -72,5 +71,4 @@ Executable runtests
    Extensions: ExistentialQuantification,
                ForeignFunctionInterface,
                EmptyDataDecls,
-               ScopedTypeVariables,
                ScopedTypeVariables

--- a/HDBC-sqlite3.cabal
+++ b/HDBC-sqlite3.cabal
@@ -57,6 +57,7 @@ Executable runtests
                   TestUtils,
                   Testbasics,
                   Tests,
+                  TestTime,
                   Database.HDBC.Sqlite3.Connection,
                   Database.HDBC.Sqlite3.ConnectionImpl,
                   Database.HDBC.Sqlite3.Statement,

--- a/HDBC-sqlite3.cabal
+++ b/HDBC-sqlite3.cabal
@@ -68,7 +68,8 @@ Executable runtests
    Extra-Libraries: sqlite3
    Hs-Source-Dirs: ., testsrc
    GHC-Options: -O2
-   Extensions: ExistentialQuantification,
+   Extensions: CPP,
+               ExistentialQuantification,
                ForeignFunctionInterface,
                EmptyDataDecls,
                ScopedTypeVariables

--- a/testsrc/TestSbasics.hs
+++ b/testsrc/TestSbasics.hs
@@ -3,7 +3,10 @@ import Test.HUnit
 import Database.HDBC
 import TestUtils
 import System.IO
-import Control.Exception hiding (catch)
+#if !MIN_VERSION_base(4,6,0)
+import Prelude hiding (catch)
+#endif
+import Control.Exception
 
 openClosedb = sqlTestCase $ 
     do dbh <- connectDB
@@ -140,7 +143,7 @@ testWithTransaction = dbTestCase (\dbh ->
        -- Let's try a rollback.
        catch (withTransaction dbh (\_ -> do sExecuteMany sth rows
                                             fail "Foo"))
-             (\_ -> return ())
+             (\(_::IOException) -> return ())
        sExecute qrysth []
        sFetchAllRows qrysth >>= (assertEqual "rollback" [[Just "0"]])
 

--- a/testsrc/Testbasics.hs
+++ b/testsrc/Testbasics.hs
@@ -3,7 +3,10 @@ import Test.HUnit
 import Database.HDBC
 import TestUtils
 import System.IO
-import Control.Exception hiding (catch)
+#if !MIN_VERSION_base(4,6,0)
+import Prelude hiding (catch)
+#endif
+import Control.Exception
 
 openClosedb = sqlTestCase $ 
     do dbh <- connectDB
@@ -140,7 +143,7 @@ testWithTransaction = dbTestCase (\dbh ->
        -- Let's try a rollback.
        catch (withTransaction dbh (\_ -> do executeMany sth rows
                                             fail "Foo"))
-             (\_ -> return ())
+             (\(_::IOException) -> return ())
        execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "rollback" [[SqlString "0"]])
 


### PR DESCRIPTION
This fixes a few easy issues with the test suite.

Unfortunately, it still won't run on an up-to-date system: you get old-time/locale conflicts in TestTime.hs. Those are less easy to fix and I don't know how to do it without breaking backwards compatibility.
