### PR TITLE
Significant performance improvements and code cleanup

### DIFF
--- a/Database/HDBC/Sqlite3.hs
+++ b/Database/HDBC/Sqlite3.hs
@@ -15,13 +15,17 @@ Written by John Goerzen, jgoerzen\@complete.org
 module Database.HDBC.Sqlite3
     (
     -- * Sqlite3 Basics
-     connectSqlite3, connectSqlite3Raw, Connection(), setBusyTimeout,
+     connectSqlite3, connectSqlite3Raw, connectSqlite3Ext, Connection(),
+     setBusyTimeout,
     -- * Sqlite3 Error Consts
     module Database.HDBC.Sqlite3.Consts
     )
 
 where
 
-import Database.HDBC.Sqlite3.Connection(connectSqlite3, connectSqlite3Raw, Connection())
+import Database.HDBC.Sqlite3.Connection( connectSqlite3
+                                       , connectSqlite3Raw
+                                       , connectSqlite3Ext
+                                       , Connection())
 import Database.HDBC.Sqlite3.ConnectionImpl(setBusyTimeout)
 import Database.HDBC.Sqlite3.Consts

--- a/Database/HDBC/Sqlite3/Consts.hsc
+++ b/Database/HDBC/Sqlite3/Consts.hsc
@@ -31,8 +31,6 @@ module Database.HDBC.Sqlite3.Consts
   sqlite_DONE)
 where
 
-import Foreign.C.Types
-
 #include <sqlite3.h>
 
 -- | Successful result

--- a/Database/HDBC/Sqlite3/Utils.hsc
+++ b/Database/HDBC/Sqlite3/Utils.hsc
@@ -12,7 +12,6 @@ import Database.HDBC.Sqlite3.Types
 import qualified Data.ByteString as B
 import qualified Data.ByteString.UTF8 as BUTF8
 import Foreign.C.Types
-import Control.Exception
 import Foreign.Storable
 
 #include "hdbc-sqlite3-helper.h"

--- a/HDBC-sqlite3.cabal
+++ b/HDBC-sqlite3.cabal
@@ -45,8 +45,13 @@ Library
 Executable runtests
    if flag(buildtests)
       Buildable: True
-      Build-Depends: HUnit, testpack, containers, convertible, 
-                  old-time, time, old-locale
+      Build-Depends: HUnit
+                   , QuickCheck
+                   , testpack
+                   , template-haskell
+                   , containers
+                   , convertible
+                   , time
    else
       Buildable: False
    Main-Is: runtests.hs
@@ -54,9 +59,11 @@ Executable runtests
                   SpecificDBTests,
                   TestMisc,
                   TestSbasics,
+                  TestTime,
                   TestUtils,
                   Testbasics,
                   Tests,
+                  Database.HDBC.Sqlite3,
                   Database.HDBC.Sqlite3.Connection,
                   Database.HDBC.Sqlite3.ConnectionImpl,
                   Database.HDBC.Sqlite3.Statement,

--- a/HDBC-sqlite3.cabal
+++ b/HDBC-sqlite3.cabal
@@ -35,7 +35,7 @@ Library
    Database.HDBC.Sqlite3.Types,
    Database.HDBC.Sqlite3.Utils,
    Database.HDBC.Sqlite3.Consts
-  GHC-Options: -O2
+  GHC-Options: -O2 -Wall
   Extensions: ExistentialQuantification,
               ForeignFunctionInterface,
               EmptyDataDecls,
@@ -74,7 +74,7 @@ Executable runtests
    include-dirs: .
    Extra-Libraries: sqlite3
    Hs-Source-Dirs: ., testsrc
-   GHC-Options: -O2
+   GHC-Options: -O2 -Wall
    Extensions: ExistentialQuantification,
                ForeignFunctionInterface,
                EmptyDataDecls,

--- a/hdbc-sqlite3-helper.c
+++ b/hdbc-sqlite3-helper.c
@@ -81,7 +81,7 @@ int sqlite3_prepare2(finalizeonce *fdb, const char *zSql,
                      int nBytes, finalizeonce **ppo,
                      const char **pzTail) {
 
-  sqlite3_stmt *ppst;
+  sqlite3_stmt *ppst = NULL;
   sqlite3 *db;
   finalizeonce *newobj;
   int res;

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,8 @@
+resolver: lts-6.35
+extra-deps:
+- testpack-2.1.3.0
+- HUnit-1.2.5.2
+- QuickCheck-2.7.6
+- template-haskell-2.10.0.0
+flags: {}
+extra-package-dbs: []

--- a/testsrc/SpecificDB.hs
+++ b/testsrc/SpecificDB.hs
@@ -6,6 +6,10 @@ connectDB :: IO Connection
 connectDB = 
     handleSqlError (connectSqlite3 "testtmp.sql3")
 
+connectDBExt :: Bool -> IO Connection
+connectDBExt auto =
+    handleSqlError (connectSqlite3Ext auto False "testtmp.sql3")
+
 dateTimeTypeOfSqlValue :: SqlValue -> String
 dateTimeTypeOfSqlValue (SqlPOSIXTime _) = "TEXT"
 dateTimeTypeOfSqlValue (SqlEpochTime _) = "INTEGER"

--- a/testsrc/SpecificDB.hs
+++ b/testsrc/SpecificDB.hs
@@ -1,8 +1,8 @@
 module SpecificDB where
 import Database.HDBC
 import Database.HDBC.Sqlite3
-import Test.HUnit
 
+connectDB :: IO Connection
 connectDB = 
     handleSqlError (connectSqlite3 "testtmp.sql3")
 
@@ -11,4 +11,5 @@ dateTimeTypeOfSqlValue (SqlPOSIXTime _) = "TEXT"
 dateTimeTypeOfSqlValue (SqlEpochTime _) = "INTEGER"
 dateTimeTypeOfSqlValue _ = "TEXT"
 
+supportsFracTime :: Bool
 supportsFracTime = True

--- a/testsrc/SpecificDBTests.hs
+++ b/testsrc/SpecificDBTests.hs
@@ -3,10 +3,12 @@ import Database.HDBC
 import Test.HUnit
 import TestMisc(setup)
 
-testgetTables :: Test
-testgetTables = setup $ \dbh ->
+testgetTables :: Bool -> Test
+testgetTables auto = setup auto $ \dbh ->
     do r <- getTables dbh
        ["hdbctest2"] @=? r
 
 tests :: Test
-tests = TestList [TestLabel "getTables" testgetTables]
+tests = TestList [ TestLabel "getTables auto-finish on"  (testgetTables True)
+                 , TestLabel "getTables auto-finish off" (testgetTables False)
+                 ]

--- a/testsrc/SpecificDBTests.hs
+++ b/testsrc/SpecificDBTests.hs
@@ -1,11 +1,12 @@
 module SpecificDBTests where
 import Database.HDBC
-import Database.HDBC.Sqlite3
 import Test.HUnit
 import TestMisc(setup)
 
+testgetTables :: Test
 testgetTables = setup $ \dbh ->
     do r <- getTables dbh
        ["hdbctest2"] @=? r
 
+tests :: Test
 tests = TestList [TestLabel "getTables" testgetTables]

--- a/testsrc/TestMisc.hs
+++ b/testsrc/TestMisc.hs
@@ -19,16 +19,24 @@ colnames = ["testid", "teststring", "testint"]
 alrows :: [[(String, SqlValue)]]
 alrows = map (zip colnames) rowdata
 
-setup :: (Connection -> IO ()) -> Test
-setup f = dbTestCase $ \dbh ->
+setup :: Bool -> (Connection -> IO ()) -> Test
+setup auto f = dbTestCaseExt auto $ \dbh ->
    do _ <- run dbh "CREATE TABLE hdbctest2 (testid INTEGER PRIMARY KEY NOT NULL, teststring TEXT, testint INTEGER)" []
       sth <- prepare dbh "INSERT INTO hdbctest2 VALUES (?, ?, ?)"
       executeMany sth rowdata
+      when (not auto) $ finish sth
       commit dbh
       finally (f dbh)
               (do _ <- run dbh "DROP TABLE hdbctest2" []
                   commit dbh
               )
+
+safeQuickQuery' :: Connection -> String -> [SqlValue] -> IO [[SqlValue]]
+safeQuickQuery' conn query args = do
+    bracket (prepare conn query)
+            (finish) $ \sth -> do
+        _ <- execute sth args
+        fetchAllRows' sth
 
 cloneTest :: forall b conn. IConnection conn =>
              conn -> (conn -> IO b) -> IO b
@@ -37,16 +45,16 @@ cloneTest dbh a =
        finally (handleSqlError (a dbh2))
                (handleSqlError (disconnect dbh2))
 
-testgetColumnNames :: Test
-testgetColumnNames = setup $ \dbh ->
+testgetColumnNames :: Bool -> Test
+testgetColumnNames auto = setup auto $ \dbh ->
    do sth <- prepare dbh "SELECT * from hdbctest2"
       _ <- execute sth []
       cols <- getColumnNames sth
       finish sth
       ["testid", "teststring", "testint"] @=? map (map toLower) cols
 
-testdescribeResult :: Test
-testdescribeResult = setup $ \dbh -> when (not ((hdbcDriverName dbh) `elem`
+testdescribeResult :: Bool -> Test
+testdescribeResult auto = setup auto $ \dbh -> when (not ((hdbcDriverName dbh) `elem`
                                                ["sqlite3"])) $
    do sth <- prepare dbh "SELECT * from hdbctest2"
       _ <- execute sth []
@@ -61,8 +69,8 @@ testdescribeResult = setup $ \dbh -> when (not ((hdbcDriverName dbh) `elem`
                             [SqlBigIntT, SqlIntegerT])
       finish sth
 
-testdescribeTable :: Test
-testdescribeTable = setup $ \dbh -> when (not ((hdbcDriverName dbh) `elem`
+testdescribeTable :: Bool -> Test
+testdescribeTable auto = setup auto $ \dbh -> when (not ((hdbcDriverName dbh) `elem`
                                                ["sqlite3"])) $
    do cols <- describeTable dbh "hdbctest2"
       ["testid", "teststring", "testint"] @=? map (map toLower . fst) cols
@@ -77,13 +85,15 @@ testdescribeTable = setup $ \dbh -> when (not ((hdbcDriverName dbh) `elem`
                            [SqlBigIntT, SqlIntegerT])
       assertEqual "r2 nullable" (Just True) (colNullable (coldata !! 2))
 
-testquickQuery :: Test
-testquickQuery = setup $ \dbh ->
+-- Quick query creates a hidden prepared statement in the parent HDBC
+-- library, and is not suitable for use without auto-finish.
+testquickQuery :: Bool -> Test
+testquickQuery _ = setup True $ \dbh ->
     do results <- quickQuery dbh "SELECT * from hdbctest2 ORDER BY testid" []
        rowdata @=? results
 
-testfetchRowAL :: Test
-testfetchRowAL = setup $ \dbh ->
+testfetchRowAL :: Bool -> Test
+testfetchRowAL auto = setup auto $ \dbh ->
     do sth <- prepare dbh "SELECT * from hdbctest2 ORDER BY testid" 
        _ <- execute sth []
        fetchRowAL sth >>= (Just (head alrows) @=?)
@@ -92,8 +102,8 @@ testfetchRowAL = setup $ \dbh ->
        fetchRowAL sth >>= (Nothing @=?)
        finish sth
 
-testfetchRowMap :: Test
-testfetchRowMap = setup $ \dbh ->
+testfetchRowMap :: Bool -> Test
+testfetchRowMap auto = setup auto $ \dbh ->
     do sth <- prepare dbh "SELECT * from hdbctest2 ORDER BY testid" 
        _ <- execute sth []
        fetchRowMap sth >>= (Just (Map.fromList $ head alrows) @=?)
@@ -102,28 +112,31 @@ testfetchRowMap = setup $ \dbh ->
        fetchRowMap sth >>= (Nothing @=?)
        finish sth
 
-testfetchAllRowsAL :: Test
-testfetchAllRowsAL = setup $ \dbh ->
+testfetchAllRowsAL :: Bool -> Test
+testfetchAllRowsAL auto = setup auto $ \dbh ->
     do sth <- prepare dbh "SELECT * from hdbctest2 ORDER BY testid"
        _ <- execute sth []
        fetchAllRowsAL sth >>= (alrows @=?)
+       when (not auto) $ finish sth
 
-testfetchAllRowsMap :: Test
-testfetchAllRowsMap = setup $ \dbh ->
+testfetchAllRowsMap :: Bool -> Test
+testfetchAllRowsMap auto = setup auto $ \dbh ->
     do sth <- prepare dbh "SELECT * from hdbctest2 ORDER BY testid"
        _ <- execute sth []
        fetchAllRowsMap sth >>= (map (Map.fromList) alrows @=?)
+       when (not auto) $ finish sth
 
-testexception :: Test
-testexception = setup $ \dbh ->
-    catchSql (do sth <- prepare dbh "SELECT invalidcol FROM hdbctest2"
-                 _ <- execute sth []
+testexception :: Bool -> Test
+testexception auto = setup auto $ \dbh ->
+    catchSql (do bracket (prepare dbh "SELECT invalidcol FROM hdbctest2")
+                         (finish)
+                         (flip execute []) >> return ()
                  assertFailure "No exception was raised"
              )
              (\_ -> commit dbh)
 
-testrowcount :: Test
-testrowcount = setup $ \dbh ->
+testrowcount :: Bool -> Test
+testrowcount auto = setup auto $ \dbh ->
     do r <- run dbh "UPDATE hdbctest2 SET testint = 25 WHERE testid = 20" []
        assertEqual "UPDATE with no change" 0 r
        r' <- run dbh "UPDATE hdbctest2 SET testint = 26 WHERE testid = 0" []
@@ -131,7 +144,7 @@ testrowcount = setup $ \dbh ->
        r'' <- run dbh "UPDATE hdbctest2 SET testint = 27 WHERE testid <> 0" []
        assertEqual "UPDATE with 2 changes" 2 r''
        commit dbh
-       res <- quickQuery dbh "SELECT * from hdbctest2 ORDER BY testid" []
+       res <- safeQuickQuery' dbh "SELECT * from hdbctest2 ORDER BY testid" []
        assertEqual "final results"
          [[SqlInt32 0, toSql "Testing", SqlInt32 26],
           [SqlInt32 1, toSql "Foo", SqlInt32 27],
@@ -141,30 +154,30 @@ testrowcount = setup $ \dbh ->
 list here (though a SpecificDB test case may be able to).  We can ensure
 that our test table is, or is not, present, as appropriate. -}
                                       
-testgetTables1 :: Test
-testgetTables1 = setup $ \dbh ->
+testgetTables1 :: Bool -> Test
+testgetTables1 auto = setup auto $ \dbh ->
     do r <- getTables dbh
        True @=? "hdbctest2" `elem` r
 
-testgetTables2 :: Test
-testgetTables2 = dbTestCase $ \dbh ->
+testgetTables2 :: Bool -> Test
+testgetTables2 auto = dbTestCaseExt auto $ \dbh ->
     do r <- getTables dbh
        False @=? "hdbctest2" `elem` r
 
-testclone :: Test
-testclone = setup $ \dbho -> cloneTest dbho $ \dbh ->
-    do results <- quickQuery dbh "SELECT * from hdbctest2 ORDER BY testid" []
+testclone :: Bool -> Test
+testclone auto = setup auto $ \dbho -> cloneTest dbho $ \dbh ->
+    do results <- safeQuickQuery' dbh "SELECT * from hdbctest2 ORDER BY testid" []
        rowdata @=? results
 
-testnulls :: Test
-testnulls = setup $ \dbh ->
+testnulls :: Bool -> Test
+testnulls auto = setup auto $ \dbh ->
     do let dn = hdbcDriverName dbh
        when (not (dn `elem` ["postgresql", "odbc"])) (
           do sth <- prepare dbh "INSERT INTO hdbctest2 VALUES (?, ?, ?)"
              executeMany sth rows
              finish sth
-             res <- quickQuery dbh "SELECT * from hdbctest2 WHERE testid > 99 ORDER BY testid" []
-             seq (length res) rows @=? res
+             res <- safeQuickQuery' dbh "SELECT * from hdbctest2 WHERE testid > 99 ORDER BY testid" []
+             rows @=? res
                                              )
     where rows = [[SqlInt32 100, SqlString "foo\NULbar", SqlNull],
                   [SqlInt32 101, SqlString "bar\NUL", SqlNull],
@@ -172,30 +185,37 @@ testnulls = setup $ \dbh ->
                   [SqlInt32 103, SqlString "\xFF", SqlNull],
                   [SqlInt32 104, SqlString "regular", SqlNull]]
        
-testunicode :: Test
-testunicode = setup $ \dbh ->
+testunicode :: Bool -> Test
+testunicode auto = setup auto $ \dbh ->
       do sth <- prepare dbh "INSERT INTO hdbctest2 VALUES (?, ?, ?)"
          executeMany sth rows
          finish sth
-         res <- quickQuery dbh "SELECT * from hdbctest2 WHERE testid > 99 ORDER BY testid" []
-         seq (length res) rows @=? res
+         res <- safeQuickQuery' dbh "SELECT * from hdbctest2 WHERE testid > 99 ORDER BY testid" []
+         rows @=? res
     where rows = [[SqlInt32 100, SqlString "foo\x263a", SqlNull],
                   [SqlInt32 101, SqlString "bar\x00A3", SqlNull],
                   [SqlInt32 102, SqlString (take 263 (repeat 'a')), SqlNull]]
 
+autoTests :: Bool -> Test
+autoTests auto = TestList
+    [ TestLabel "getColumnNames" (testgetColumnNames auto)
+    , TestLabel "describeResult" (testdescribeResult auto)
+    , TestLabel "describeTable" (testdescribeTable auto)
+    , TestLabel "quickQuery" (testquickQuery auto)
+    , TestLabel "fetchRowAL" (testfetchRowAL auto)
+    , TestLabel "fetchRowMap" (testfetchRowMap auto)
+    , TestLabel "fetchAllRowsAL" (testfetchAllRowsAL auto)
+    , TestLabel "fetchAllRowsMap" (testfetchAllRowsMap auto)
+    , TestLabel "sql exception" (testexception auto)
+    , TestLabel "clone" (testclone auto)
+    , TestLabel "update rowcount" (testrowcount auto)
+    , TestLabel "get tables1" (testgetTables1 auto)
+    , TestLabel "get tables2" (testgetTables2 auto)
+    , TestLabel "nulls" (testnulls auto)
+    , TestLabel "unicode" (testunicode auto)
+    ]
+
 tests :: Test
-tests = TestList [TestLabel "getColumnNames" testgetColumnNames,
-                  TestLabel "describeResult" testdescribeResult,
-                  TestLabel "describeTable" testdescribeTable,
-                  TestLabel "quickQuery" testquickQuery,
-                  TestLabel "fetchRowAL" testfetchRowAL,
-                  TestLabel "fetchRowMap" testfetchRowMap,
-                  TestLabel "fetchAllRowsAL" testfetchAllRowsAL,
-                  TestLabel "fetchAllRowsMap" testfetchAllRowsMap,
-                  TestLabel "sql exception" testexception,
-                  TestLabel "clone" testclone,
-                  TestLabel "update rowcount" testrowcount,
-                  TestLabel "get tables1" testgetTables1,
-                  TestLabel "get tables2" testgetTables2,
-                  TestLabel "nulls" testnulls,
-                  TestLabel "unicode" testunicode]
+tests = TestList [ TestLabel "auto-finish on"  (autoTests True)
+                 , TestLabel "auto-finish off" (autoTests False)
+                 ]

--- a/testsrc/TestMisc.hs
+++ b/testsrc/TestMisc.hs
@@ -1,48 +1,55 @@
 module TestMisc(tests, setup) where
 import Test.HUnit
 import Database.HDBC
+import Database.HDBC.Sqlite3
 import TestUtils
-import System.IO
 import Control.Exception
 import Data.Char
 import Control.Monad
 import qualified Data.Map as Map
 
+rowdata :: [[SqlValue]]
 rowdata = 
     [[SqlInt32 0, toSql "Testing", SqlNull],
      [SqlInt32 1, toSql "Foo", SqlInt32 5],
      [SqlInt32 2, toSql "Bar", SqlInt32 9]]
 
+colnames :: [String]
 colnames = ["testid", "teststring", "testint"]
 alrows :: [[(String, SqlValue)]]
 alrows = map (zip colnames) rowdata
 
+setup :: (Connection -> IO ()) -> Test
 setup f = dbTestCase $ \dbh ->
-   do run dbh "CREATE TABLE hdbctest2 (testid INTEGER PRIMARY KEY NOT NULL, teststring TEXT, testint INTEGER)" []
+   do _ <- run dbh "CREATE TABLE hdbctest2 (testid INTEGER PRIMARY KEY NOT NULL, teststring TEXT, testint INTEGER)" []
       sth <- prepare dbh "INSERT INTO hdbctest2 VALUES (?, ?, ?)"
       executeMany sth rowdata
       commit dbh
       finally (f dbh)
-              (do run dbh "DROP TABLE hdbctest2" []
+              (do _ <- run dbh "DROP TABLE hdbctest2" []
                   commit dbh
               )
 
+cloneTest :: forall b conn. IConnection conn =>
+             conn -> (conn -> IO b) -> IO b
 cloneTest dbh a =
     do dbh2 <- clone dbh
        finally (handleSqlError (a dbh2))
                (handleSqlError (disconnect dbh2))
 
+testgetColumnNames :: Test
 testgetColumnNames = setup $ \dbh ->
    do sth <- prepare dbh "SELECT * from hdbctest2"
-      execute sth []
+      _ <- execute sth []
       cols <- getColumnNames sth
       finish sth
       ["testid", "teststring", "testint"] @=? map (map toLower) cols
 
+testdescribeResult :: Test
 testdescribeResult = setup $ \dbh -> when (not ((hdbcDriverName dbh) `elem`
                                                ["sqlite3"])) $
    do sth <- prepare dbh "SELECT * from hdbctest2"
-      execute sth []
+      _ <- execute sth []
       cols <- describeResult sth
       ["testid", "teststring", "testint"] @=? map (map toLower . fst) cols
       let coldata = map snd cols
@@ -54,6 +61,7 @@ testdescribeResult = setup $ \dbh -> when (not ((hdbcDriverName dbh) `elem`
                             [SqlBigIntT, SqlIntegerT])
       finish sth
 
+testdescribeTable :: Test
 testdescribeTable = setup $ \dbh -> when (not ((hdbcDriverName dbh) `elem`
                                                ["sqlite3"])) $
    do cols <- describeTable dbh "hdbctest2"
@@ -69,52 +77,59 @@ testdescribeTable = setup $ \dbh -> when (not ((hdbcDriverName dbh) `elem`
                            [SqlBigIntT, SqlIntegerT])
       assertEqual "r2 nullable" (Just True) (colNullable (coldata !! 2))
 
+testquickQuery :: Test
 testquickQuery = setup $ \dbh ->
     do results <- quickQuery dbh "SELECT * from hdbctest2 ORDER BY testid" []
        rowdata @=? results
 
+testfetchRowAL :: Test
 testfetchRowAL = setup $ \dbh ->
     do sth <- prepare dbh "SELECT * from hdbctest2 ORDER BY testid" 
-       execute sth []
+       _ <- execute sth []
        fetchRowAL sth >>= (Just (head alrows) @=?)
        fetchRowAL sth >>= (Just (alrows !! 1) @=?)
        fetchRowAL sth >>= (Just (alrows !! 2) @=?)
        fetchRowAL sth >>= (Nothing @=?)
        finish sth
 
+testfetchRowMap :: Test
 testfetchRowMap = setup $ \dbh ->
     do sth <- prepare dbh "SELECT * from hdbctest2 ORDER BY testid" 
-       execute sth []
+       _ <- execute sth []
        fetchRowMap sth >>= (Just (Map.fromList $ head alrows) @=?)
        fetchRowMap sth >>= (Just (Map.fromList $ alrows !! 1) @=?)
        fetchRowMap sth >>= (Just (Map.fromList $ alrows !! 2) @=?)
        fetchRowMap sth >>= (Nothing @=?)
        finish sth
 
+testfetchAllRowsAL :: Test
 testfetchAllRowsAL = setup $ \dbh ->
     do sth <- prepare dbh "SELECT * from hdbctest2 ORDER BY testid"
-       execute sth []
+       _ <- execute sth []
        fetchAllRowsAL sth >>= (alrows @=?)
 
+testfetchAllRowsMap :: Test
 testfetchAllRowsMap = setup $ \dbh ->
     do sth <- prepare dbh "SELECT * from hdbctest2 ORDER BY testid"
-       execute sth []
+       _ <- execute sth []
        fetchAllRowsMap sth >>= (map (Map.fromList) alrows @=?)
 
+testexception :: Test
 testexception = setup $ \dbh ->
     catchSql (do sth <- prepare dbh "SELECT invalidcol FROM hdbctest2"
-                 execute sth []
+                 _ <- execute sth []
                  assertFailure "No exception was raised"
              )
-             (\e -> commit dbh)
+             (\_ -> commit dbh)
 
+testrowcount :: Test
 testrowcount = setup $ \dbh ->
     do r <- run dbh "UPDATE hdbctest2 SET testint = 25 WHERE testid = 20" []
        assertEqual "UPDATE with no change" 0 r
-       r <- run dbh "UPDATE hdbctest2 SET testint = 26 WHERE testid = 0" []
-       assertEqual "UPDATE with 1 change" 1 r
-       r <- run dbh "UPDATE hdbctest2 SET testint = 27 WHERE testid <> 0" []
-       assertEqual "UPDATE with 2 changes" 2 r
+       r' <- run dbh "UPDATE hdbctest2 SET testint = 26 WHERE testid = 0" []
+       assertEqual "UPDATE with 1 change" 1 r'
+       r'' <- run dbh "UPDATE hdbctest2 SET testint = 27 WHERE testid <> 0" []
+       assertEqual "UPDATE with 2 changes" 2 r''
        commit dbh
        res <- quickQuery dbh "SELECT * from hdbctest2 ORDER BY testid" []
        assertEqual "final results"
@@ -126,18 +141,22 @@ testrowcount = setup $ \dbh ->
 list here (though a SpecificDB test case may be able to).  We can ensure
 that our test table is, or is not, present, as appropriate. -}
                                       
+testgetTables1 :: Test
 testgetTables1 = setup $ \dbh ->
     do r <- getTables dbh
        True @=? "hdbctest2" `elem` r
 
+testgetTables2 :: Test
 testgetTables2 = dbTestCase $ \dbh ->
     do r <- getTables dbh
        False @=? "hdbctest2" `elem` r
 
+testclone :: Test
 testclone = setup $ \dbho -> cloneTest dbho $ \dbh ->
     do results <- quickQuery dbh "SELECT * from hdbctest2 ORDER BY testid" []
        rowdata @=? results
 
+testnulls :: Test
 testnulls = setup $ \dbh ->
     do let dn = hdbcDriverName dbh
        when (not (dn `elem` ["postgresql", "odbc"])) (
@@ -153,6 +172,7 @@ testnulls = setup $ \dbh ->
                   [SqlInt32 103, SqlString "\xFF", SqlNull],
                   [SqlInt32 104, SqlString "regular", SqlNull]]
        
+testunicode :: Test
 testunicode = setup $ \dbh ->
       do sth <- prepare dbh "INSERT INTO hdbctest2 VALUES (?, ?, ?)"
          executeMany sth rows
@@ -163,6 +183,7 @@ testunicode = setup $ \dbh ->
                   [SqlInt32 101, SqlString "bar\x00A3", SqlNull],
                   [SqlInt32 102, SqlString (take 263 (repeat 'a')), SqlNull]]
 
+tests :: Test
 tests = TestList [TestLabel "getColumnNames" testgetColumnNames,
                   TestLabel "describeResult" testdescribeResult,
                   TestLabel "describeTable" testdescribeTable,

--- a/testsrc/TestSbasics.hs
+++ b/testsrc/TestSbasics.hs
@@ -2,21 +2,23 @@ module TestSbasics(tests) where
 import Test.HUnit
 import Database.HDBC
 import TestUtils
-import System.IO
 import Control.Exception
 
+openClosedb :: Test
 openClosedb = sqlTestCase $ 
     do dbh <- connectDB
        disconnect dbh
 
+multiFinish :: Test
 multiFinish = dbTestCase (\dbh ->
     do sth <- prepare dbh "SELECT 1 + 1"
-       sExecute sth []
+       _ <- sExecute sth []
        finish sth
        finish sth
        finish sth
                           )
 
+runRawTest :: Test
 runRawTest = dbTestCase (\dbh ->
     do runRaw dbh "CREATE TABLE valid1 (a int); CREATE TABLE valid2 (a int)"
        tables <- getTables dbh
@@ -25,6 +27,7 @@ runRawTest = dbTestCase (\dbh ->
                         )
 
 
+runRawErrorTest :: Test
 runRawErrorTest = dbTestCase (\dbh ->
     do err <- (runRaw dbh "CREATE TABLE valid1 (a int); INVALID" >> return "No error") `catchSql`
               (return . seErrorMsg)
@@ -34,29 +37,33 @@ runRawErrorTest = dbTestCase (\dbh ->
        assertBool "valid1 table created!" (not $ "valid1" `elem` tables)
                         )
 
+basicQueries :: Test
 basicQueries = dbTestCase (\dbh ->
     do sth <- prepare dbh "SELECT 1 + 1"
-       sExecute sth []
+       _ <- sExecute sth []
        sFetchRow sth >>= (assertEqual "row 1" (Just [Just "2"]))
        sFetchRow sth >>= (assertEqual "last row" Nothing)
                           )
     
+createTable :: Test
 createTable = dbTestCase (\dbh ->
-    do sRun dbh "CREATE TABLE hdbctest1 (testname VARCHAR(20), testid INTEGER, testint INTEGER, testtext TEXT)" []
+    do _ <- sRun dbh "CREATE TABLE hdbctest1 (testname VARCHAR(20), testid INTEGER, testint INTEGER, testtext TEXT)" []
        commit dbh
                          )
 
+dropTable :: Test
 dropTable = dbTestCase (\dbh ->
-    do sRun dbh "DROP TABLE hdbctest1" []
+    do _ <- sRun dbh "DROP TABLE hdbctest1" []
        commit dbh
                        )
 
+runReplace :: Test
 runReplace = dbTestCase (\dbh ->
-    do sRun dbh "INSERT INTO hdbctest1 VALUES (?, ?, ?, ?)" r1
-       sRun dbh "INSERT INTO hdbctest1 VALUES (?, ?, 2, ?)" r2
+    do _ <- sRun dbh "INSERT INTO hdbctest1 VALUES (?, ?, ?, ?)" r1
+       _ <- sRun dbh "INSERT INTO hdbctest1 VALUES (?, ?, 2, ?)" r2
        commit dbh
        sth <- prepare dbh "SELECT * FROM hdbctest1 WHERE testname = 'runReplace' ORDER BY testid"
-       sExecute sth []
+       _ <- sExecute sth []
        sFetchRow sth >>= (assertEqual "r1" (Just r1))
        sFetchRow sth >>= (assertEqual "r2" (Just [Just "runReplace", Just "2",
                                                  Just "2", Nothing]))
@@ -65,92 +72,98 @@ runReplace = dbTestCase (\dbh ->
     where r1 = [Just "runReplace", Just "1", Just "1234", Just "testdata"]
           r2 = [Just "runReplace", Just "2", Nothing]
 
+executeReplace :: Test
 executeReplace = dbTestCase (\dbh ->
     do sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('executeReplace',?,?,?)"
-       sExecute sth [Just "1", Just "1234", Just "Foo"]
-       sExecute sth [Just "2", Nothing, Just "Bar"]
+       _ <- sExecute sth [Just "1", Just "1234", Just "Foo"]
+       _ <- sExecute sth [Just "2", Nothing, Just "Bar"]
        commit dbh
-       sth <- prepare dbh "SELECT * FROM hdbctest1 WHERE testname = ? ORDER BY testid"
-       sExecute sth [Just "executeReplace"]
-       sFetchRow sth >>= (assertEqual "r1" 
+       sth' <- prepare dbh "SELECT * FROM hdbctest1 WHERE testname = ? ORDER BY testid"
+       _ <- sExecute sth' [Just "executeReplace"]
+       sFetchRow sth' >>= (assertEqual "r1"
                          (Just $ map Just ["executeReplace", "1", "1234", 
                                            "Foo"]))
-       sFetchRow sth >>= (assertEqual "r2"
+       sFetchRow sth' >>= (assertEqual "r2"
                          (Just [Just "executeReplace", Just "2", Nothing,
                                 Just "Bar"]))
-       sFetchRow sth >>= (assertEqual "lastrow" Nothing)
+       sFetchRow sth' >>= (assertEqual "lastrow" Nothing)
                             )
 
+testExecuteMany :: Test
 testExecuteMany = dbTestCase (\dbh ->
     do sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('multi',?,?,?)"
        sExecuteMany sth rows
        commit dbh
-       sth <- prepare dbh "SELECT testid, testint, testtext FROM hdbctest1 WHERE testname = 'multi'"
-       sExecute sth []
-       mapM_ (\r -> sFetchRow sth >>= (assertEqual "" (Just r))) rows
+       sth' <- prepare dbh "SELECT testid, testint, testtext FROM hdbctest1 WHERE testname = 'multi' ORDER BY testid"
+       _ <- sExecute sth' []
+       mapM_ (\r -> sFetchRow sth' >>= (assertEqual "" (Just r))) rows
        sFetchRow sth >>= (assertEqual "lastrow" Nothing)
                           )
     where rows = [map Just ["1", "1234", "foo"],
                   map Just ["2", "1341", "bar"],
                   [Just "3", Nothing, Nothing]]
 
+testsFetchAllRows :: Test
 testsFetchAllRows = dbTestCase (\dbh ->
     do sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('sFetchAllRows', ?, NULL, NULL)"
        sExecuteMany sth rows
        commit dbh
-       sth <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'sFetchAllRows' ORDER BY testid"
-       sExecute sth []
-       results <- sFetchAllRows sth
+       sth' <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'sFetchAllRows' ORDER BY testid"
+       _ <- sExecute sth' []
+       results <- sFetchAllRows sth'
        assertEqual "" rows results
                                )
-    where rows = map (\x -> [Just . show $ x]) [1..9]
+    where rows = map (\x -> [Just . show $ x]) ([1..9 :: Int])
 
+basicTransactions :: Test
 basicTransactions = dbTestCase (\dbh ->
     do assertBool "Connected database does not support transactions; skipping transaction test" (dbTransactionSupport dbh)
        sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('basicTransactions', ?, NULL, NULL)"
-       sExecute sth [Just "0"]
+       _ <- sExecute sth [Just "0"]
        commit dbh
        qrysth <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'basicTransactions' ORDER BY testid"
-       sExecute qrysth []
+       _ <- sExecute qrysth []
        sFetchAllRows qrysth >>= (assertEqual "initial commit" [[Just "0"]])
 
        -- Now try a rollback
        sExecuteMany sth rows
        rollback dbh
-       sExecute qrysth []
+       _ <- sExecute qrysth []
        sFetchAllRows qrysth >>= (assertEqual "rollback" [[Just "0"]])
 
        -- Now try another commit
        sExecuteMany sth rows
        commit dbh
-       sExecute qrysth []
+       _ <- sExecute qrysth []
        sFetchAllRows qrysth >>= (assertEqual "final commit" ([Just "0"]:rows))
                                )
-    where rows = map (\x -> [Just . show $ x]) [1..9]
+    where rows = map (\x -> [Just . show $ x]) ([1..9 :: Int])
 
+testWithTransaction :: Test
 testWithTransaction = dbTestCase (\dbh ->
     do assertBool "Connected database does not support transactions; skipping transaction test" (dbTransactionSupport dbh)
        sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('withTransaction', ?, NULL, NULL)"
-       sExecute sth [Just "0"]
+       _ <- sExecute sth [Just "0"]
        commit dbh
        qrysth <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'withTransaction' ORDER BY testid"
-       sExecute qrysth []
+       _ <- sExecute qrysth []
        sFetchAllRows qrysth >>= (assertEqual "initial commit" [[Just "0"]])
        
        -- Let's try a rollback.
        catch (withTransaction dbh (\_ -> do sExecuteMany sth rows
                                             fail "Foo"))
              ( (\_ -> return ()) :: SomeException -> IO () )
-       sExecute qrysth []
+       _ <- sExecute qrysth []
        sFetchAllRows qrysth >>= (assertEqual "rollback" [[Just "0"]])
 
        -- And now a commit.
        withTransaction dbh (\_ -> sExecuteMany sth rows)
-       sExecute qrysth []
+       _ <- sExecute qrysth []
        sFetchAllRows qrysth >>= (assertEqual "final commit" ([Just "0"]:rows))
                                )
-    where rows = map (\x -> [Just . show $ x]) [1..9]
+    where rows = map (\x -> [Just . show $ x]) ([1..9 :: Int])
        
+tests :: Test
 tests = TestList
         [
          TestLabel "openClosedb" openClosedb,

--- a/testsrc/TestSbasics.hs
+++ b/testsrc/TestSbasics.hs
@@ -3,7 +3,7 @@ import Test.HUnit
 import Database.HDBC
 import TestUtils
 import System.IO
-import Control.Exception hiding (catch)
+import Control.Exception
 
 openClosedb = sqlTestCase $ 
     do dbh <- connectDB
@@ -140,7 +140,7 @@ testWithTransaction = dbTestCase (\dbh ->
        -- Let's try a rollback.
        catch (withTransaction dbh (\_ -> do sExecuteMany sth rows
                                             fail "Foo"))
-             (\_ -> return ())
+             ( (\_ -> return ()) :: SomeException -> IO () )
        sExecute qrysth []
        sFetchAllRows qrysth >>= (assertEqual "rollback" [[Just "0"]])
 

--- a/testsrc/TestTime.hs
+++ b/testsrc/TestTime.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module TestTime(tests) where
 import Test.HUnit
@@ -6,53 +9,67 @@ import Database.HDBC
 import TestUtils
 import Control.Exception
 import Data.Time
-import Data.Time.LocalTime
-import Data.Time.Clock
 import Data.Time.Clock.POSIX
 import Data.Maybe
 import Data.Convertible
 import SpecificDB
 
-instance Eq ZonedTime where
-    a == b = zonedTimeToUTC a == zonedTimeToUTC b &&
-             zonedTimeZone a == zonedTimeZone b
+newtype ZonedTimeEq = ZonedTimeEq { _zt :: ZonedTime }
 
-testZonedTime :: ZonedTime
-testZonedTime = fromJust $ parseTimeM True defaultTimeLocale (iso8601DateFormat (Just "%T %z"))
+instance Show ZonedTimeEq where
+    show = show . _zt
+
+instance Eq ZonedTimeEq where
+    a == b = let a' = _zt a
+                 b' = _zt b
+              in zonedTimeToUTC a' == zonedTimeToUTC b' &&
+                 zonedTimeZone a' == zonedTimeZone b'
+
+instance (Convertible a ZonedTime) => (Convertible a ZonedTimeEq) where
+    safeConvert v = ZonedTimeEq <$> (safeConvert v)
+instance (Convertible ZonedTime b) => (Convertible ZonedTimeEq b) where
+    safeConvert (ZonedTimeEq v) = safeConvert v
+
+testZonedTime :: ZonedTimeEq
+testZonedTime = ZonedTimeEq . fromJust $ parseTimeM True defaultTimeLocale (iso8601DateFormat (Just "%T %z"))
                  "1989-08-01T15:33:01 -0500"
 
-testZonedTimeFrac :: ZonedTime
-testZonedTimeFrac = fromJust $ parseTimeM True defaultTimeLocale (iso8601DateFormat (Just "%T%Q %z"))
+testZonedTimeFrac :: ZonedTimeEq
+testZonedTimeFrac = ZonedTimeEq . fromJust $ parseTimeM True defaultTimeLocale (iso8601DateFormat (Just "%T%Q %z"))
                     "1989-08-01T15:33:01.536 -0500"
 
-
-rowdata t = [[SqlInt32 100, toSql t, SqlNull]]
-
+testDTType :: forall a. (Eq a, Show a, Convertible SqlValue a) =>
+              a -> (a -> SqlValue) -> Test
 testDTType inputdata convToSqlValue = dbTestCase $ \dbh ->
     do runRaw dbh ("CREATE TABLE hdbctesttime (testid INTEGER PRIMARY KEY NOT NULL, \
                 \testvalue " ++ dateTimeTypeOfSqlValue value ++ ")")
-       finally (testIt dbh) (do commit dbh
-                                runRaw dbh "DROP TABLE hdbctesttime"
-                                commit dbh
-                            )
-    where testIt dbh =
-              do run dbh "INSERT INTO hdbctesttime (testid, testvalue) VALUES (?, ?)"
-                     [iToSql 5, value]
+       finally (convcmp dbh) (do commit dbh
+                                 runRaw dbh "DROP TABLE hdbctesttime"
+                                 commit dbh
+                             )
+    where convcmp dbh =
+              do _ <- run dbh "INSERT INTO hdbctesttime (testid, testvalue) VALUES (?, ?)"
+                      [iToSql 5, value]
                  commit dbh
                  r <- quickQuery' dbh "SELECT testid, testvalue FROM hdbctesttime" []
                  case r of
                    [[testidsv, testvaluesv]] -> 
                        do assertEqual "testid" (5::Int) (fromSql testidsv)
                           assertEqual "testvalue" inputdata (fromSql testvaluesv)
+                   _ -> assertEqual "testquery" "one pair" "not one pair"
           value = convToSqlValue inputdata
 
+mkTest :: forall a. (Eq a, Show a, Convertible SqlValue a) =>
+           String -> a -> (a -> SqlValue) -> Test
 mkTest label inputdata convfunc =
     TestLabel label (testDTType inputdata convfunc)
 
+tests :: Test
 tests = TestList $
     ((TestLabel "Non-frac" $ testIt testZonedTime) :
      if supportsFracTime then [TestLabel "Frac" $ testIt testZonedTimeFrac] else [])
 
+testIt :: ZonedTimeEq -> Test
 testIt baseZonedTime = 
     TestList [mkTest "Day" baseDay toSql,
               mkTest "TimeOfDay" baseTimeOfDay toSql,
@@ -72,10 +89,10 @@ testIt baseZonedTime =
       baseTimeOfDay = localTimeOfDay baseLocalTime
 
       baseZonedTimeOfDay :: (TimeOfDay, TimeZone)
-      baseZonedTimeOfDay = fromSql (SqlZonedTime baseZonedTime)
+      baseZonedTimeOfDay = fromSql (SqlZonedTime $ _zt baseZonedTime)
 
       baseLocalTime :: LocalTime
-      baseLocalTime = zonedTimeToLocalTime baseZonedTime
+      baseLocalTime = zonedTimeToLocalTime $ _zt baseZonedTime
 
       baseUTCTime :: UTCTime
       baseUTCTime = convert baseZonedTime

--- a/testsrc/TestUtils.hs
+++ b/testsrc/TestUtils.hs
@@ -1,9 +1,9 @@
-module TestUtils(connectDB, sqlTestCase, dbTestCase, printDBInfo) where
+module TestUtils(connectDB, connectDBExt, sqlTestCase, dbTestCase, dbTestCaseExt, printDBInfo) where
 import Database.HDBC
 import Database.HDBC.Sqlite3
 import Test.HUnit
 import Control.Exception
-import SpecificDB(connectDB)
+import SpecificDB(connectDB, connectDBExt)
 
 sqlTestCase :: IO () -> Test
 sqlTestCase a = 
@@ -12,6 +12,13 @@ sqlTestCase a =
 dbTestCase :: (Connection -> IO ()) -> Test
 dbTestCase a =
     TestCase (do dbh <- connectDB
+                 finally (handleSqlError (a dbh))
+                         (handleSqlError (disconnect dbh))
+             )
+
+dbTestCaseExt :: Bool -> (Connection -> IO()) -> Test
+dbTestCaseExt auto a =
+    TestCase (do dbh <- connectDBExt auto
                  finally (handleSqlError (a dbh))
                          (handleSqlError (disconnect dbh))
              )

--- a/testsrc/TestUtils.hs
+++ b/testsrc/TestUtils.hs
@@ -1,18 +1,22 @@
 module TestUtils(connectDB, sqlTestCase, dbTestCase, printDBInfo) where
 import Database.HDBC
+import Database.HDBC.Sqlite3
 import Test.HUnit
 import Control.Exception
 import SpecificDB(connectDB)
 
+sqlTestCase :: IO () -> Test
 sqlTestCase a = 
     TestCase (handleSqlError a)
 
+dbTestCase :: (Connection -> IO ()) -> Test
 dbTestCase a =
     TestCase (do dbh <- connectDB
                  finally (handleSqlError (a dbh))
                          (handleSqlError (disconnect dbh))
              )
 
+printDBInfo :: IO ()
 printDBInfo = handleSqlError $
     do dbh <- connectDB
        putStrLn "+-------------------------------------------------------------------------"

--- a/testsrc/Testbasics.hs
+++ b/testsrc/Testbasics.hs
@@ -3,24 +3,23 @@ import Test.HUnit
 import Database.HDBC
 import TestUtils
 import Control.Exception
+import Control.Monad (when)
 
-openClosedb :: Test
-openClosedb = sqlTestCase $ 
-    do dbh <- connectDB
+openClosedb :: Bool -> Test
+openClosedb auto = sqlTestCase $
+    do dbh <- connectDBExt auto
        disconnect dbh
 
-multiFinish :: Test
-multiFinish = dbTestCase (\dbh ->
+multiFinish :: Bool -> Test
+multiFinish auto = dbTestCaseExt auto (\dbh ->
     do sth <- prepare dbh "SELECT 1 + 1"
        r <- execute sth []
        assertEqual "basic count" 0 r
-       finish sth
-       finish sth
-       finish sth
+       finish sth >> finish sth >> finish sth
                           )
 
-basicQueries :: Test
-basicQueries = dbTestCase (\dbh ->
+basicQueries :: Bool -> Test
+basicQueries auto = dbTestCaseExt auto (\dbh ->
     do sth <- prepare dbh "SELECT 1 + 1"
        execute sth [] >>= (0 @=?)
        r <- fetchAllRows sth
@@ -30,22 +29,23 @@ basicQueries = dbTestCase (\dbh ->
        assertEqual "num compare" [[toSql (2::Int)]] r
        assertEqual "nToSql compare" [[nToSql (2::Int)]] r
        assertEqual "string compare" [[SqlString "2"]] r
+       when (not auto) $ finish sth
                           )
-    
-createTable :: Test
-createTable = dbTestCase (\dbh ->
+
+createTable :: Bool -> Test
+createTable auto = dbTestCaseExt auto (\dbh ->
     do runRaw dbh "CREATE TABLE hdbctest1 (testname VARCHAR(20), testid INTEGER, testint INTEGER, testtext TEXT)"
        commit dbh
                          )
 
-dropTable :: Test
-dropTable = dbTestCase (\dbh ->
+dropTable :: Bool -> Test
+dropTable auto = dbTestCaseExt auto (\dbh ->
     do runRaw dbh "DROP TABLE hdbctest1"
        commit dbh
                        )
 
-runReplace :: Test
-runReplace = dbTestCase (\dbh ->
+runReplace :: Bool -> Test
+runReplace auto = dbTestCaseExt auto (\dbh ->
     do r <- run dbh "INSERT INTO hdbctest1 VALUES (?, ?, ?, ?)" r1
        assertEqual "insert retval" 1 r
        _ <- run dbh "INSERT INTO hdbctest1 VALUES (?, ?, ?, ?)" r2
@@ -55,15 +55,17 @@ runReplace = dbTestCase (\dbh ->
        assertEqual "select retval" 0 rv2
        r' <- fetchAllRows sth
        assertEqual "" [r1, r2] r'
+       when (not auto) $ finish sth
                        )
-    where r1 = [toSql "runReplace", iToSql 1, iToSql 1234, SqlString "testdata"] 
+    where r1 = [toSql "runReplace", iToSql 1, iToSql 1234, SqlString "testdata"]
           r2 = [toSql "runReplace", iToSql 2, iToSql 2, SqlNull]
 
-executeReplace :: Test
-executeReplace = dbTestCase (\dbh ->
+executeReplace :: Bool -> Test
+executeReplace auto = dbTestCaseExt auto (\dbh ->
     do sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('executeReplace',?,?,?)"
        _ <- execute sth [iToSql 1, iToSql 1234, toSql "Foo"]
        _ <- execute sth [SqlInt32 2, SqlNull, toSql "Bar"]
+       when (not auto) $ finish sth
        commit dbh
        sth' <- prepare dbh "SELECT * FROM hdbctest1 WHERE testname = ? ORDER BY testid"
        _ <- execute sth' [SqlString "executeReplace"]
@@ -74,48 +76,55 @@ executeReplace = dbTestCase (\dbh ->
                     [toSql "executeReplace", iToSql 2, SqlNull,
                      toSql "Bar"]]
                    r
+       when (not auto) $ finish sth'
                             )
 
-testExecuteMany :: Test
-testExecuteMany = dbTestCase (\dbh ->
+testExecuteMany :: Bool -> Test
+testExecuteMany auto = dbTestCaseExt auto (\dbh ->
     do sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('multi',?,?,?)"
        executeMany sth rows
        commit dbh
+       when (not auto) $ finish sth
        sth' <- prepare dbh "SELECT testid, testint, testtext FROM hdbctest1 WHERE testname = 'multi'"
        _ <- execute sth' []
        r <- fetchAllRows sth'
        assertEqual "" rows r
+       when (not auto) $ finish sth'
                           )
     where rows = [map toSql ["1", "1234", "foo"],
                   map toSql ["2", "1341", "bar"],
                   [toSql "3", SqlNull, SqlNull]]
 
-testFetchAllRows :: Test
-testFetchAllRows = dbTestCase (\dbh ->
+testFetchAllRows :: Bool -> Test
+testFetchAllRows auto = dbTestCaseExt auto (\dbh ->
     do sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('fetchAllRows', ?, NULL, NULL)"
        executeMany sth rows
        commit dbh
+       when (not auto) $ finish sth
        sth' <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'fetchAllRows' ORDER BY testid"
        _ <- execute sth' []
        results <- fetchAllRows sth'
        assertEqual "" rows results
+       when (not auto) $ finish sth'
                                )
     where rows = map (\x -> [iToSql x]) [1..9]
 
-testFetchAllRows' :: Test
-testFetchAllRows' = dbTestCase (\dbh ->
+testFetchAllRows' :: Bool -> Test
+testFetchAllRows' auto = dbTestCaseExt auto (\dbh ->
     do sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('fetchAllRows2', ?, NULL, NULL)"
        executeMany sth rows
        commit dbh
+       when (not auto) $ finish sth
        sth' <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'fetchAllRows2' ORDER BY testid"
        _ <- execute sth' []
        results <- fetchAllRows' sth'
+       when (not auto) $ finish sth'
        assertEqual "" rows results
                                )
     where rows = map (\x -> [iToSql x]) [1..9]
 
-basicTransactions :: Test
-basicTransactions = dbTestCase (\dbh ->
+basicTransactions :: Bool -> Test
+basicTransactions auto = dbTestCaseExt auto (\dbh ->
     do assertBool "Connected database does not support transactions; skipping transaction test" (dbTransactionSupport dbh)
        sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('basicTransactions', ?, NULL, NULL)"
        _ <- execute sth [iToSql 0]
@@ -135,11 +144,12 @@ basicTransactions = dbTestCase (\dbh ->
        commit dbh
        _ <- execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "final commit" ([SqlString "0"]:rows))
+       when (not auto) $ finish sth >> finish qrysth
                                )
     where rows = map (\x -> [iToSql $ x]) [1..9]
 
-testWithTransaction :: Test
-testWithTransaction = dbTestCase (\dbh ->
+testWithTransaction :: Bool -> Test
+testWithTransaction auto = dbTestCaseExt auto (\dbh ->
     do assertBool "Connected database does not support transactions; skipping transaction test" (dbTransactionSupport dbh)
        sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('withTransaction', ?, NULL, NULL)"
        _ <- execute sth [toSql "0"]
@@ -147,7 +157,7 @@ testWithTransaction = dbTestCase (\dbh ->
        qrysth <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'withTransaction' ORDER BY testid"
        _ <- execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "initial commit" [[toSql "0"]])
-       
+
        -- Let's try a rollback.
        catch (withTransaction dbh (\_ -> do executeMany sth rows
                                             fail "Foo"))
@@ -159,22 +169,28 @@ testWithTransaction = dbTestCase (\dbh ->
        withTransaction dbh (\_ -> executeMany sth rows)
        _ <- execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "final commit" ([iToSql 0]:rows))
+       when (not auto) $ finish sth >> finish qrysth
                                )
     where rows = map (\x -> [iToSql x]) [1..9]
-       
+
+autoTests :: Bool -> Test
+autoTests auto = TestList
+    [ TestLabel "openClosedb" (openClosedb auto)
+    , TestLabel "multiFinish" (multiFinish auto)
+    , TestLabel "basicQueries" (basicQueries auto)
+    , TestLabel "createTable" (createTable auto)
+    , TestLabel "runReplace" (runReplace auto)
+    , TestLabel "executeReplace" (executeReplace auto)
+    , TestLabel "executeMany" (testExecuteMany auto)
+    , TestLabel "fetchAllRows" (testFetchAllRows auto)
+    , TestLabel "fetchAllRows'" (testFetchAllRows' auto)
+    , TestLabel "basicTransactions" (basicTransactions auto)
+    , TestLabel "withTransaction" (testWithTransaction auto)
+    , TestLabel "dropTable" (dropTable True)
+    ]
+
 tests :: Test
 tests = TestList
-        [
-         TestLabel "openClosedb" openClosedb,
-         TestLabel "multiFinish" multiFinish,
-         TestLabel "basicQueries" basicQueries,
-         TestLabel "createTable" createTable,
-         TestLabel "runReplace" runReplace,
-         TestLabel "executeReplace" executeReplace,
-         TestLabel "executeMany" testExecuteMany,
-         TestLabel "fetchAllRows" testFetchAllRows,
-         TestLabel "fetchAllRows'" testFetchAllRows',
-         TestLabel "basicTransactions" basicTransactions,
-         TestLabel "withTransaction" testWithTransaction,
-         TestLabel "dropTable" dropTable
-         ]
+    [ TestLabel "Auto-finish true tests" (autoTests True)
+    , TestLabel "Auto-finish false tests" (autoTests False)
+    ]

--- a/testsrc/Testbasics.hs
+++ b/testsrc/Testbasics.hs
@@ -3,7 +3,7 @@ import Test.HUnit
 import Database.HDBC
 import TestUtils
 import System.IO
-import Control.Exception hiding (catch)
+import Control.Exception
 
 openClosedb = sqlTestCase $ 
     do dbh <- connectDB
@@ -140,7 +140,7 @@ testWithTransaction = dbTestCase (\dbh ->
        -- Let's try a rollback.
        catch (withTransaction dbh (\_ -> do executeMany sth rows
                                             fail "Foo"))
-             (\_ -> return ())
+             ( (\_ -> return ()) :: SomeException -> IO () )
        execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "rollback" [[SqlString "0"]])
 

--- a/testsrc/Testbasics.hs
+++ b/testsrc/Testbasics.hs
@@ -2,13 +2,14 @@ module Testbasics(tests) where
 import Test.HUnit
 import Database.HDBC
 import TestUtils
-import System.IO
 import Control.Exception
 
+openClosedb :: Test
 openClosedb = sqlTestCase $ 
     do dbh <- connectDB
        disconnect dbh
 
+multiFinish :: Test
 multiFinish = dbTestCase (\dbh ->
     do sth <- prepare dbh "SELECT 1 + 1"
        r <- execute sth []
@@ -18,6 +19,7 @@ multiFinish = dbTestCase (\dbh ->
        finish sth
                           )
 
+basicQueries :: Test
 basicQueries = dbTestCase (\dbh ->
     do sth <- prepare dbh "SELECT 1 + 1"
        execute sth [] >>= (0 @=?)
@@ -30,38 +32,42 @@ basicQueries = dbTestCase (\dbh ->
        assertEqual "string compare" [[SqlString "2"]] r
                           )
     
+createTable :: Test
 createTable = dbTestCase (\dbh ->
-    do run dbh "CREATE TABLE hdbctest1 (testname VARCHAR(20), testid INTEGER, testint INTEGER, testtext TEXT)" []
+    do runRaw dbh "CREATE TABLE hdbctest1 (testname VARCHAR(20), testid INTEGER, testint INTEGER, testtext TEXT)"
        commit dbh
                          )
 
+dropTable :: Test
 dropTable = dbTestCase (\dbh ->
-    do run dbh "DROP TABLE hdbctest1" []
+    do runRaw dbh "DROP TABLE hdbctest1"
        commit dbh
                        )
 
+runReplace :: Test
 runReplace = dbTestCase (\dbh ->
     do r <- run dbh "INSERT INTO hdbctest1 VALUES (?, ?, ?, ?)" r1
        assertEqual "insert retval" 1 r
-       run dbh "INSERT INTO hdbctest1 VALUES (?, ?, ?, ?)" r2
+       _ <- run dbh "INSERT INTO hdbctest1 VALUES (?, ?, ?, ?)" r2
        commit dbh
        sth <- prepare dbh "SELECT * FROM hdbctest1 WHERE testname = 'runReplace' ORDER BY testid"
        rv2 <- execute sth []
        assertEqual "select retval" 0 rv2
-       r <- fetchAllRows sth
-       assertEqual "" [r1, r2] r
+       r' <- fetchAllRows sth
+       assertEqual "" [r1, r2] r'
                        )
     where r1 = [toSql "runReplace", iToSql 1, iToSql 1234, SqlString "testdata"] 
           r2 = [toSql "runReplace", iToSql 2, iToSql 2, SqlNull]
 
+executeReplace :: Test
 executeReplace = dbTestCase (\dbh ->
     do sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('executeReplace',?,?,?)"
-       execute sth [iToSql 1, iToSql 1234, toSql "Foo"]
-       execute sth [SqlInt32 2, SqlNull, toSql "Bar"]
+       _ <- execute sth [iToSql 1, iToSql 1234, toSql "Foo"]
+       _ <- execute sth [SqlInt32 2, SqlNull, toSql "Bar"]
        commit dbh
-       sth <- prepare dbh "SELECT * FROM hdbctest1 WHERE testname = ? ORDER BY testid"
-       execute sth [SqlString "executeReplace"]
-       r <- fetchAllRows sth
+       sth' <- prepare dbh "SELECT * FROM hdbctest1 WHERE testname = ? ORDER BY testid"
+       _ <- execute sth' [SqlString "executeReplace"]
+       r <- fetchAllRows sth'
        assertEqual "result"
                    [[toSql "executeReplace", iToSql 1, toSql "1234",
                      toSql "Foo"],
@@ -70,87 +76,93 @@ executeReplace = dbTestCase (\dbh ->
                    r
                             )
 
+testExecuteMany :: Test
 testExecuteMany = dbTestCase (\dbh ->
     do sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('multi',?,?,?)"
        executeMany sth rows
        commit dbh
-       sth <- prepare dbh "SELECT testid, testint, testtext FROM hdbctest1 WHERE testname = 'multi'"
-       execute sth []
-       r <- fetchAllRows sth
+       sth' <- prepare dbh "SELECT testid, testint, testtext FROM hdbctest1 WHERE testname = 'multi'"
+       _ <- execute sth' []
+       r <- fetchAllRows sth'
        assertEqual "" rows r
                           )
     where rows = [map toSql ["1", "1234", "foo"],
                   map toSql ["2", "1341", "bar"],
                   [toSql "3", SqlNull, SqlNull]]
 
+testFetchAllRows :: Test
 testFetchAllRows = dbTestCase (\dbh ->
     do sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('fetchAllRows', ?, NULL, NULL)"
        executeMany sth rows
        commit dbh
-       sth <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'fetchAllRows' ORDER BY testid"
-       execute sth []
-       results <- fetchAllRows sth
+       sth' <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'fetchAllRows' ORDER BY testid"
+       _ <- execute sth' []
+       results <- fetchAllRows sth'
        assertEqual "" rows results
                                )
     where rows = map (\x -> [iToSql x]) [1..9]
 
+testFetchAllRows' :: Test
 testFetchAllRows' = dbTestCase (\dbh ->
     do sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('fetchAllRows2', ?, NULL, NULL)"
        executeMany sth rows
        commit dbh
-       sth <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'fetchAllRows2' ORDER BY testid"
-       execute sth []
-       results <- fetchAllRows' sth
+       sth' <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'fetchAllRows2' ORDER BY testid"
+       _ <- execute sth' []
+       results <- fetchAllRows' sth'
        assertEqual "" rows results
                                )
     where rows = map (\x -> [iToSql x]) [1..9]
 
+basicTransactions :: Test
 basicTransactions = dbTestCase (\dbh ->
     do assertBool "Connected database does not support transactions; skipping transaction test" (dbTransactionSupport dbh)
        sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('basicTransactions', ?, NULL, NULL)"
-       execute sth [iToSql 0]
+       _ <- execute sth [iToSql 0]
        commit dbh
        qrysth <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'basicTransactions' ORDER BY testid"
-       execute qrysth []
+       _ <- execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "initial commit" [[toSql "0"]])
 
        -- Now try a rollback
        executeMany sth rows
        rollback dbh
-       execute qrysth []
+       _ <- execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "rollback" [[toSql "0"]])
 
        -- Now try another commit
        executeMany sth rows
        commit dbh
-       execute qrysth []
+       _ <- execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "final commit" ([SqlString "0"]:rows))
                                )
     where rows = map (\x -> [iToSql $ x]) [1..9]
 
+testWithTransaction :: Test
 testWithTransaction = dbTestCase (\dbh ->
     do assertBool "Connected database does not support transactions; skipping transaction test" (dbTransactionSupport dbh)
        sth <- prepare dbh "INSERT INTO hdbctest1 VALUES ('withTransaction', ?, NULL, NULL)"
-       execute sth [toSql "0"]
+       _ <- execute sth [toSql "0"]
        commit dbh
        qrysth <- prepare dbh "SELECT testid FROM hdbctest1 WHERE testname = 'withTransaction' ORDER BY testid"
-       execute qrysth []
+       _ <- execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "initial commit" [[toSql "0"]])
        
        -- Let's try a rollback.
        catch (withTransaction dbh (\_ -> do executeMany sth rows
                                             fail "Foo"))
              ( (\_ -> return ()) :: SomeException -> IO () )
-       execute qrysth []
+       _ <- execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "rollback" [[SqlString "0"]])
 
        -- And now a commit.
        withTransaction dbh (\_ -> executeMany sth rows)
-       execute qrysth []
+       _ <- execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "final commit" ([iToSql 0]:rows))
                                )
     where rows = map (\x -> [iToSql x]) [1..9]
        
+tests :: Test
 tests = TestList
         [
          TestLabel "openClosedb" openClosedb,

--- a/testsrc/Tests.hs
+++ b/testsrc/Tests.hs
@@ -9,8 +9,10 @@ import qualified SpecificDBTests
 import qualified TestMisc
 import qualified TestTime
 
+test1 :: Test
 test1 = TestCase ("x" @=? "x")
 
+tests :: Test
 tests = TestList [TestLabel "test1" test1,
                   TestLabel "String basics" TestSbasics.tests,
                   TestLabel "SqlValue basics" Testbasics.tests,

--- a/testsrc/runtests.hs
+++ b/testsrc/runtests.hs
@@ -7,6 +7,7 @@ import Test.HUnit
 import Tests
 import TestUtils
 
+main :: IO ()
 main = do printDBInfo
-          runTestTT tests
+          runTestTT tests >> return ()
 


### PR DESCRIPTION
* Most, if not all, compiler warnings resolved
* Major performance boost from avoiding integer (and double) conversions from strings.
* Major performance boost from new [non-default] connection mode with the autoFinish boolean parameter disabled.

Disabling auto-finish retains open prepared statement handles, which the application is responsible to manage and release before disconnect.  For applications that frequently run the same query this can be a significant speedup.  Some HDBC functions (queryQuery and quickQuery' are unsafe in this mode and should be avoided).

A mock-up of an an application that repeatedly queries for the same 8 rows 10000 times saw a change in runtime from 13.6 seconds to 5.7 seconds.