### PR TITLE
cabal: Add pkgconfig-depends declaration

### DIFF
--- a/HDBC-sqlite3.cabal
+++ b/HDBC-sqlite3.cabal
@@ -27,6 +27,7 @@ Library
 
   C-Sources: hdbc-sqlite3-helper.c
   include-dirs: .
+  Pkgconfig-Depends: sqlite3
   Extra-Libraries: sqlite3
   Exposed-Modules: Database.HDBC.Sqlite3
   Other-Modules: Database.HDBC.Sqlite3.Connection,


### PR DESCRIPTION
This allows the library to be [transparently found](https://github.com/bgamari/nix-pkgconfig) on systems like NixOS.